### PR TITLE
Refactor from Fragment Shader to VisualServer

### DIFF
--- a/lib/SpriteStacking/scenes/Billboard.tscn
+++ b/lib/SpriteStacking/scenes/Billboard.tscn
@@ -1,36 +1,6 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://lib/SpriteStacking/scripts/Billboard.gd" type="Script" id=1]
 
-[sub_resource type="Shader" id=2]
-code = "shader_type canvas_item;
-render_mode unshaded, skip_vertex_transform;
-
-uniform lowp float stretch : hint_range(1, 64);
-
-void vertex() {
-	vec2 scale = vec2(
-		sqrt(pow(WORLD_MATRIX[0][0], 2) + pow(WORLD_MATRIX[0][1], 2)),
-		sqrt(pow(WORLD_MATRIX[1][0], 2) + pow(WORLD_MATRIX[1][1], 2))
-	);
-	
-	mat4 billboard = WORLD_MATRIX;
-
-	billboard[0][0] = scale.x;
-	billboard[0][1] = 0f;
-
-	billboard[1][0] = 0f;
-	billboard[1][1] = scale.y * stretch;
-	
-	VERTEX = (EXTRA_MATRIX * (billboard * vec4(VERTEX, 0.0, 1.0))).xy;
-}
-"
-custom_defines = ""
-
-[sub_resource type="ShaderMaterial" id=3]
-shader = SubResource( 2 )
-shader_param/stretch = 1
-
 [node name="Billboard" type="Sprite"]
-material = SubResource( 3 )
 script = ExtResource( 1 )

--- a/lib/SpriteStacking/scenes/StackedSprite.tscn
+++ b/lib/SpriteStacking/scenes/StackedSprite.tscn
@@ -1,16 +1,6 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://lib/SpriteStacking/shaders/StackedSprite.shader" type="Shader" id=1]
 [ext_resource path="res://lib/SpriteStacking/scripts/StackedSprite.gd" type="Script" id=2]
 
-[sub_resource type="ShaderMaterial" id=1]
-shader = ExtResource( 1 )
-shader_param/columns = 1
-shader_param/rows = 1
-shader_param/layer_count = 1
-shader_param/stretch = 1
-shader_param/center = 0
-
 [node name="StackedSprite" type="Node2D"]
-material = SubResource( 1 )
 script = ExtResource( 2 )

--- a/lib/SpriteStacking/scripts/StackedSprite.gd
+++ b/lib/SpriteStacking/scripts/StackedSprite.gd
@@ -1,84 +1,45 @@
 tool
 extends Node2D
 
-export var slice_sheet : Texture = null setget set_slice_sheet  # LIMITATION: All layers must border with transparent pixels
-export var columns : int = 1 setget set_columns
-export var rows : int = 1 setget set_rows
-export var static_z : bool = false setget set_static_z # Don't dynamically calculate Z value
-export var height : int = 0 setget set_center; # 0 is on the floor. Adjust values if stack is above/below the floor
+export var slice_sheet : Texture = null
+export var columns : int = 1
+export var rows : int = 1
+export var static_z : bool = false # Don't dynamically calculate Z value
+export var height : int = 0 # 0 is on the floor. Adjust values if stack is above/below the floor
 
-var layer_count : int;
-
-const SHADER = preload("res://lib/SpriteStacking/shaders/StackedSprite.shader")
-
-var Mat;
-var sheet_size = Vector2(64, 64);
-var layer_size = Vector2(64, 64);
-
-func sync_material():
-	Mat.set_shader_param("slice_sheet", slice_sheet);
-	Mat.set_shader_param("columns", columns);
-	Mat.set_shader_param("rows", rows);
-	Mat.set_shader_param("layer_count", layer_count);
-	Mat.set_shader_param("stretch", SsGlobals.cam_pitch if not Engine.editor_hint else 1);
-	Mat.set_shader_param("center", height);
+var ci_rid
 
 func _ready():
-	setup_shader();
-
-func setup_shader():
-	layer_count = rows * columns;
-	
-	if (slice_sheet):
-		sheet_size = slice_sheet.get_size();
-		layer_size = Vector2(sheet_size.x / columns, sheet_size.y / rows);
-	
-	Mat = ShaderMaterial.new()
-	Mat.shader = SHADER
-	self.set_material(Mat)
-	call_deferred("sync_material");
+	# Create a canvas item, child of this node.
+	ci_rid = VisualServer.canvas_item_create()
+	# Make this node the parent.
+	VisualServer.canvas_item_set_parent(ci_rid, get_canvas_item())
 
 func _process(_delta):
-	if (not static_z):
-		var cam_rot = get_viewport_transform().get_rotation()
-		z_index = global_position.rotated(cam_rot).y;
+	var sheet_size = slice_sheet.get_size()
+	var layer_size = sheet_size / Vector2(columns, rows)
+	var cam_rot = get_viewport_transform().get_rotation()
 	
+	# Draw things on the top of the screen first
+	z_index = global_position.rotated(cam_rot).y;
 
-func _draw():
-	# TODO: draw a polygon that's only the visible parts and dynamic uv mapping
-	draw_rect(Rect2(
-		-layer_size / 2,
+	# Keep stacks going towards the top of the screen
+	var cam_up = Vector2(sin(cam_rot + rotation), cos(cam_rot + rotation)) * -1
+
+	# TODO: Does clearing every process create overhead?
+	VisualServer.canvas_item_clear(ci_rid);
+
+	var base_rect = Rect2(
+		Vector2.ZERO,
 		layer_size
-	), Color.black, true);
+	)
+	base_rect.position = -base_rect.size / 2
 	
-	# Draw a bigger bounding rect to prevent off-screen culling too early
-	var largest_possible_size = layer_size + Vector2(layer_count, layer_count) * 2;
-	draw_rect(Rect2(
-		-largest_possible_size / 2,
-		largest_possible_size
-	), Color.transparent, false);
-
-# Engine Hints
-
-func on_value_change():
-	setup_shader();
-
-func set_slice_sheet(new_value):
-	slice_sheet = new_value;
-	on_value_change();
-
-func set_columns(new_value):
-	columns = new_value;
-	on_value_change();
-
-func set_rows(new_value):
-	rows = new_value;
-	on_value_change();
-
-func set_static_z(new_value):
-	static_z = new_value;
-	on_value_change();
-
-func set_center(new_value):
-	height = new_value;
-	on_value_change();
+	for i in range(0, columns * rows):
+		base_rect.position += cam_up * (SsGlobals.cam_pitch if not Engine.editor_hint else 1)
+		VisualServer.canvas_item_add_texture_rect_region(
+			ci_rid,
+			base_rect,
+			slice_sheet.get_rid(),
+			Rect2(Vector2(0, sheet_size.y - i * layer_size.y), layer_size)
+		)

--- a/lib/SpriteStacking/scripts/StackedSprite.gd
+++ b/lib/SpriteStacking/scripts/StackedSprite.gd
@@ -5,7 +5,7 @@ export var slice_sheet : Texture = null setget set_slice_sheet  # LIMITATION: Al
 export var columns : int = 1 setget set_columns
 export var rows : int = 1 setget set_rows
 export var static_z : bool = false setget set_static_z # Don't dynamically calculate Z value
-export var center : int = 0 setget set_center;
+export var height : int = 0 setget set_center; # 0 is on the floor. Adjust values if stack is above/below the floor
 
 var layer_count : int;
 
@@ -21,7 +21,7 @@ func sync_material():
 	Mat.set_shader_param("rows", rows);
 	Mat.set_shader_param("layer_count", layer_count);
 	Mat.set_shader_param("stretch", SsGlobals.cam_pitch if not Engine.editor_hint else 1);
-	Mat.set_shader_param("center", center);
+	Mat.set_shader_param("center", height);
 
 func _ready():
 	setup_shader();
@@ -80,5 +80,5 @@ func set_static_z(new_value):
 	on_value_change();
 
 func set_center(new_value):
-	center = new_value;
+	height = new_value;
 	on_value_change();

--- a/lib/SpriteStacking/shaders/StackedSprite.shader
+++ b/lib/SpriteStacking/shaders/StackedSprite.shader
@@ -1,3 +1,4 @@
+// DEPRECATED
 shader_type canvas_item;
 render_mode unshaded;
 // TODO: Uncomment this when Godot ports this statement and remove all lowp


### PR DESCRIPTION
* Rename center -> height to avoid confusion
* Now uses the [direct drawing hooks](https://docs.godotengine.org/en/stable/classes/class_visualserver.html) to get way better fps.
* Billboards are still a shader because I'm lazy and I don't think there will be any performance improvement moving that back to gdscript

Closes #2