### PR TITLE
Reset2D Features and Other Stuff

### DIFF
--- a/PreviewTool/PreviewTool.tscn
+++ b/PreviewTool/PreviewTool.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=4 format=3 uid="uid://coup6rye4uqxu"]
 
 [ext_resource type="Script" path="res://addons/ShaderStacker/SpriteStack/SpriteStack.gd" id="1_17ihv"]
 [ext_resource type="Script" path="res://PreviewTool/PreviewTool.gd" id="1_m6560"]

--- a/addons/ShaderStacker/Reset2D/Reset2D.gd
+++ b/addons/ShaderStacker/Reset2D/Reset2D.gd
@@ -15,10 +15,10 @@ func _ready():
 
 func _process(delta):
 	var cam = get_viewport().get_camera_2d()
-	var cam_rot = (cam.global_rotation if cam else 1.0)
+	var cam_rot = (cam.global_rotation if cam else 0.0)
 	var squish = 1 / (cam.zoom.y if cam else 1.0)
 	
-	var up_vector = Vector2(0, -1).rotated(cam_rot - global_rotation) * squish
+	var up_vector = Vector2(0, -1).rotated(cam_rot) * squish
 	
 	if reset_scale:
 		self.scale.y = squish

--- a/addons/ShaderStacker/Reset2D/Reset2D.gd
+++ b/addons/ShaderStacker/Reset2D/Reset2D.gd
@@ -1,9 +1,11 @@
 extends Node2D
 
+
 @export_category("Reset2D")
+@export var z: int = 0
+@export var reset_position: bool = true
 @export var reset_rotation: bool = true
 @export var reset_scale: bool = true
-
 
 
 func _ready():
@@ -16,7 +18,11 @@ func _process(delta):
 	var cam_rot = (cam.global_rotation if cam else 1.0)
 	var squish = 1 / (cam.zoom.y if cam else 1.0)
 	
+	var up_vector = Vector2(0, -1).rotated(cam_rot - global_rotation) * squish
+	
 	if reset_scale:
 		self.scale.y = squish
 	if reset_rotation:
 		self.rotation = cam_rot
+	if reset_position:
+		self.position = up_vector * z

--- a/addons/ShaderStacker/Reset2D/Reset2D.gd
+++ b/addons/ShaderStacker/Reset2D/Reset2D.gd
@@ -1,4 +1,5 @@
 extends Node2D
+class_name Reset2D
 
 
 @export_category("Reset2D")

--- a/addons/ShaderStacker/SpriteStack/SpriteStack.gd
+++ b/addons/ShaderStacker/SpriteStack/SpriteStack.gd
@@ -1,5 +1,7 @@
 @tool
 extends Node2D
+class_name SpriteStack
+
 
 @export_category("Sprite Stack")
 @export var sprite_sheet: Texture = null

--- a/addons/ShaderStacker/SpriteStack/SpriteStack.gd
+++ b/addons/ShaderStacker/SpriteStack/SpriteStack.gd
@@ -34,6 +34,7 @@ func _draw():
 	var squish = (cam.zoom.x / cam.zoom.y if cam else 1.0)
 	
 	var up_vector = Vector2(0, -pitch).rotated(yaw + cam_rot - global_rotation) * squish
+	draw_set_transform(Vector2.ZERO, 0.0, Vector2(2, 2)) # Double sized pixels because they look better
 	for i in range(1, layers + 1):
 		draw_texture_rect_region(
 				sprite_sheet,

--- a/addons/ShaderStacker/StackCamera/StackCamera.gd
+++ b/addons/ShaderStacker/StackCamera/StackCamera.gd
@@ -8,6 +8,7 @@ var stackGroupName
 func _ready():
 	var id = get_viewport().get_viewport_rid().get_id()
 	stackGroupName = "zsort{viewportRID}".format({ "viewportRID": id })
+	self.ignore_rotation = false
 
 
 func _process(delta):

--- a/addons/ShaderStacker/StackCamera/StackCamera.gd
+++ b/addons/ShaderStacker/StackCamera/StackCamera.gd
@@ -1,4 +1,5 @@
 extends Camera2D
+class_name StackCamera
 
 
 var stackGroupName

--- a/docs/index.html
+++ b/docs/index.html
@@ -383,6 +383,28 @@ func ready():
             Inverse scale transforms from the current camera
           </td>
         </tr>
+        <tr>
+          <td>
+            reset_position
+          </td>
+          <td>
+            bool
+          </td>
+          <td>
+            Must be enabled for <code>z</code> to work. Will overwrite any position value so child this node to a Node2D and position that instead.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            z
+          </td>
+          <td>
+            int
+          </td>
+          <td>
+            Number of pixel "above the ground" the children appear to be
+          </td>
+        </tr>
       </table>
       <p>
         Transforms itself such that any child <code>Node2d</code> will look as expected before

--- a/docs/style.css
+++ b/docs/style.css
@@ -330,4 +330,5 @@ label, legend, fieldset {
 
 table {
   margin-bottom: 2.5rem;
+  text-align: unset;
 }

--- a/project.godot
+++ b/project.godot
@@ -9,13 +9,31 @@
 config_version=5
 
 _global_script_classes=[{
+"base": "Node2D",
+"class": &"Reset2D",
+"language": &"GDScript",
+"path": "res://addons/ShaderStacker/Reset2D/Reset2D.gd"
+}, {
 "base": "EditorPlugin",
 "class": &"ShaderStacker",
 "language": &"GDScript",
 "path": "res://addons/ShaderStacker/init.gd"
+}, {
+"base": "Node2D",
+"class": &"SpriteStack",
+"language": &"GDScript",
+"path": "res://addons/ShaderStacker/SpriteStack/SpriteStack.gd"
+}, {
+"base": "Camera2D",
+"class": &"StackCamera",
+"language": &"GDScript",
+"path": "res://addons/ShaderStacker/StackCamera/StackCamera.gd"
 }]
 _global_script_class_icons={
-"ShaderStacker": ""
+"Reset2D": "",
+"ShaderStacker": "",
+"SpriteStack": "",
+"StackCamera": ""
 }
 
 [application]


### PR DESCRIPTION
Adding micro features as I need them

- Add `reset_position` and `z` to Reset2D so stuff can be "above the ground.
- Re-add code that makes sprite stack layers render at 2x res. This ensures all pixels render on squished zoom level.
- [Fixed a bug where camera rotation correction broke](https://github.com/KarlTheCool/Shader-Stacker/issues/16)
- Renamed demo nodes to be more explicit about their purpose