### PR TITLE
Order SpriteStacks by Z value

### DIFF
--- a/addons/ShaderStacker/StackCamera/StackCamera.gd
+++ b/addons/ShaderStacker/StackCamera/StackCamera.gd
@@ -29,7 +29,7 @@ func _process(delta):
 
 func get_z_level(node):
 	var node_z = 0
-	if node is SpriteStack:
+	if node is SpriteStack or node is Reset2D:
 		node_z = node.z
 	return node_z
 

--- a/addons/ShaderStacker/StackCamera/StackCamera.gd
+++ b/addons/ShaderStacker/StackCamera/StackCamera.gd
@@ -27,5 +27,16 @@ func _process(delta):
 		spritestack_nodes[i].z_as_relative = false
 		z += 1
 
+func get_z_level(node):
+	var node_z = 0
+	if node is SpriteStack:
+		node_z = node.z
+	return node_z
+
 func screen_top_down_sort(a, b):
-	return a.global_position.rotated(-global_rotation).y < b.global_position.rotated(-global_rotation).y
+	var a_z = get_z_level(a)
+	var b_z = get_z_level(b)
+	if a_z != b_z:
+		return a_z > b_z
+	else:
+		return a.global_position.rotated(-global_rotation).y < b.global_position.rotated(-global_rotation).y


### PR DESCRIPTION
Looking to fix #17 

As the title says, StackCamera will use the z value from a SpriteStack for sorting.

![cap](https://user-images.githubusercontent.com/550176/211120181-4ea58ca1-2255-4868-a2ad-d7260f36282c.gif)
